### PR TITLE
Show product description on order modal

### DIFF
--- a/app/views/product/_show.html.slim
+++ b/app/views/product/_show.html.slim
@@ -1,5 +1,9 @@
 input type="hidden" name="product_id" value=@product.product_id
 
+- if @product.description.present?
+  p.text-secondary = @product.description
+  hr
+
 - if @product.sizes.count >= 2
   - @product.sizes.each.with_index do |size, index|
     div.form-check.size-selector


### PR DESCRIPTION
Makes it easier to see which 🧀 is already on the base 🍕 and which 🧀 is still missing.

More seriously: The product modal obstructs the product list making the product description not visible any more. This commit displays the product description above the size selection in the product modal.