### PR TITLE
Do not trip over empty extra ingredients

### DIFF
--- a/app/models/remote/product.rb
+++ b/app/models/remote/product.rb
@@ -112,6 +112,9 @@ class Remote::Product
   end
 
   def extra_ingredient_ids
+    if data['ingredient_extra_with_details'].nil?
+      return []
+    end
     data['ingredient_extras_with_details'].keys.map(&:to_i).freeze
   end
 


### PR DESCRIPTION
Items having no extra ingredients are represented inconsistently in the
JSON files. Let's no longer throw 500s here.