### PR TITLE
Finally fix #10

### DIFF
--- a/app/models/remote/product.rb
+++ b/app/models/remote/product.rb
@@ -112,9 +112,7 @@ class Remote::Product
   end
 
   def extra_ingredient_ids
-    if data['ingredient_extras_with_details'].nil?
-      return []
-    end
+    return [] unless data['ingredient_extras_with_details'].is_a?(Hash)
     data['ingredient_extras_with_details'].keys.map(&:to_i).freeze
   end
 


### PR DESCRIPTION
As upstream JSON has too many variants to break us let's simply
ignore everything that's not a hash.